### PR TITLE
Fix URL encoding for non-ASCII characters in original URLs

### DIFF
--- a/src/routes/[shortcode]/+page.server.ts
+++ b/src/routes/[shortcode]/+page.server.ts
@@ -31,7 +31,7 @@ export const load = async ({
 		if (secret === null) {
 			if (user === null || (user && user.id !== redirection.userId))
 				await markUsage(redirection, request, url, fetch);
-			throw redirect(302, redirection.original_url);
+			throw redirect(302, encodeURI(redirection.original_url));
 		} else return { ...data, shortcode, has_secret: true };
 	} else error(404, { message: 'errors.snapps.not-found' });
 };

--- a/src/routes/[shortcode]/+page.server.ts
+++ b/src/routes/[shortcode]/+page.server.ts
@@ -31,7 +31,7 @@ export const load = async ({
 		if (secret === null) {
 			if (user === null || (user && user.id !== redirection.userId))
 				await markUsage(redirection, request, url, fetch);
-			throw redirect(302, encodeURI(redirection.original_url));
+			throw redirect(302, encodeURIComponent(redirection.original_url));
 		} else return { ...data, shortcode, has_secret: true };
 	} else error(404, { message: 'errors.snapps.not-found' });
 };


### PR DESCRIPTION
## Problem

When original URLs contain non-ASCII characters, attempting to redirect to these URLs can result in 500 server errors. This prevents users from accessing shortened links that contain non-standard characters in the original URL.

Examples of problematic URLs:

1. URL with Chinese characters in the path:
   https://example.com/产品/电子设备

2. URL with Chinese domain name:
   https://例子.com/products

## Solution

This PR implements URL encoding for the original URL before redirecting. By properly encoding the URL, we ensure that all characters, including non-ASCII ones, are correctly handled during the redirection process.

Note: I'm not entirely certain if directly applying `encodeURI` to IDNs (Internationalized Domain Names) is the best approach. However, I've tested this solution on the latest versions of Chromium and Safari on macOS, and haven't encountered any issues. Further testing on different platforms and browsers may be beneficial.