### PR TITLE
fix(auth): implement OIDC username field configuration with robust fallback chain

### DIFF
--- a/src/routes/auth/[provider]/callback/+server.ts
+++ b/src/routes/auth/[provider]/callback/+server.ts
@@ -68,6 +68,20 @@ export const GET = async (event) => {
 			throw error(400, "Missing email");
 		}
 
+		// Extract username from OIDC user response using configured field mapping
+		// Fallback chain: userNameField -> userIdField -> email-based username
+		let username = oauthUser[config.rawConfig.userNameField];
+		
+		if (!username || typeof username !== "string") {
+			// First fallback: try userIdField
+			username = oauthUser[config.rawConfig.userIdField];
+		}
+		
+		if (!username || typeof username !== "string") {
+			// Final fallback: extracting username from email (legacy behavior)
+			username = email.split("@")[0];
+		}
+
 		// Replace this with your own DB client.
 		const existingUser = await prisma.user.findFirst({ where: { email } });
 
@@ -79,11 +93,15 @@ export const GET = async (event) => {
 			const enabledSignup = settings.get("ENABLE_SIGNUP");
 			if (!enabledSignup) redirect(302, "/auth/sign-up");
 			const password = generateSessionToken();
+			
+			// Use the configured username field with fallback to email-based generation
+			const cleanUsername = slugify(username.slice(0, 20));
+			
 			const user = await prisma.user.create({
 				data: {
 					email,
 					password,
-					username: slugify(email.split("@")[0].slice(0, 20)),
+					username: cleanUsername,
 					verified: true
 				}
 			});


### PR DESCRIPTION
- Respect AUTH_OIDC_USERNAME_FIELD and AUTH_OIDC_USERID_FIELD environment variables
- Implement fallback chain: userNameField -> userIdField -> email-based username
- Ensure backwards compatibility and robustness for incomplete OIDC responses
- Update comments to reflect new behavior with fallback mechanism

Previously, OIDC username mapping ignored configured field mappings and always extracted username from email local part, causing issues when AUTH_OIDC_USERNAME_FIELD was set to fields like 'sub'.

Fallback logic:
1. Try configured AUTH_OIDC_USERNAME_FIELD (e.g., 'preferred_username', 'sub')
2. Fallback to AUTH_OIDC_USERID_FIELD if first field is missing (e.g., 'sub', 'id')
3. Final fallback to email-based username generation (legacy behavior)

Example with AUTH_OIDC_USERNAME_FIELD=sub and AUTH_OIDC_USERID_FIELD=sub:
- Before: username = "namesurname" (always from email)
- After: username = "98765432" (from OIDC 'sub' field)

Fixes #143 issue where userinfo response with 'sub': '98765432' was ignored in favor of hardcoded email parsing.